### PR TITLE
EPICS_NTNDA_Viewer: PVA channelname from env

### DIFF
--- a/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
+++ b/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
@@ -127,7 +127,12 @@ public class EPICS_NTNDA_Viewer
      */
     public EPICS_NTNDA_Viewer()
     {
+        String temp=null;
         readProperties();
+        temp = System.getenv("EPICS_NTNDA_VIEWER_CHANNELNAME");
+        if (temp != null) {
+            channelName = temp;
+        }
         createAndShowGUI();
     }
     /* (non-Javadoc)


### PR DESCRIPTION
Adding the ability to optionally load a PVA channelname into the EPICS_NTNDA_Viewer plugin from an environment variable named `EPICS_NTNDA_VIEWER_CHANNELNAME`.

The value of the environment variable if present will take effect over the value from the .properties file.